### PR TITLE
Add `air_quality` and `siren` in entity platforms

### DIFF
--- a/src/const.py
+++ b/src/const.py
@@ -1,4 +1,5 @@
 ENTITY_PLATFORMS = [
+    "air_quality",
     "alarm_control_panel",
     "binary_sensor",
     "button",
@@ -19,6 +20,7 @@ ENTITY_PLATFORMS = [
     "remote",
     "select",
     "sensor",
+    "siren",
     "stt",
     "switch",
     "text",


### PR DESCRIPTION
I noticed that the `air_quality` and `siren` platforms are missing, I added in the `ENTITY_PLATFORMS` constant, but I'm not sure if that alone is enough.

If there is a reason why they are left out or you would like to resolve this in another way, please feel free to close this.