### PR TITLE
Adds the newly added entity domains: `event`, `lawn_mower`, `todo` and `wake_word`

### DIFF
--- a/src/const.py
+++ b/src/const.py
@@ -10,9 +10,11 @@ ENTITY_PLATFORMS = [
     "date",
     "datetime",
     "device_tracker",
+    "event",
     "fan",
     "humidifier",
     "image",
+    "lawn_mower",
     "light",
     "lock",
     "media_player",
@@ -25,9 +27,11 @@ ENTITY_PLATFORMS = [
     "switch",
     "text",
     "time",
+    "todo",
     "tts",
     "update",
     "vacuum",
+    "wake_word",
     "water_heater",
     "weather"
 ]


### PR DESCRIPTION
Add the newly added entity domains to the core:
* [event](https://developers.home-assistant.io/docs/core/entity/event/)
* [lawn_mower](https://developers.home-assistant.io/docs/core/entity/lawn-mower/)
* [todo](https://developers.home-assistant.io/docs/core/entity/todo/)
* [wake_word](https://developers.home-assistant.io/docs/core/entity/wake_word/)